### PR TITLE
prepare to release in appstore

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,10 +15,9 @@
 	<bugs>https://github.com/nextcloud/user_external/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/user_external.git</repository>
 	<dependencies>
-		<nextcloud min-version="13" max-version="15" />
+		<nextcloud min-version="15" max-version="15" />
 	</dependencies>
-	<version>0.4</version>
-	<shipped>true</shipped>
+	<version>0.5</version>
 	<types>
 		<authentication/>
 		<prelogin/>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@
 	<dependencies>
 		<nextcloud min-version="15" max-version="15" />
 	</dependencies>
-	<version>0.5</version>
+	<version>0.5.0</version>
 	<types>
 		<authentication/>
 		<prelogin/>


### PR DESCRIPTION
- [X] remove shipped flag
- [X] set min-version to 15 (so it can't be installed from store _and_ shipped; for 15.0.0 broken anyway)
- [X] bump version to 0.5.0 (.0 as of #30)
- [x] change Author to "Nextcloud"? --  just do be set in the appstore (https://github.com/nextcloud/app-certificate-requests/pull/208#issuecomment-450890782)


- [x] change build script for 15.0.1 to not include user_external (probably not in this PR - nextcloud/server#13225)

for #22 

cc @jancborchardt @MariusBluem @rullzer 
Signed-off-by: Jonas Sulzer <jonas@violoncello.ch>