### PR TITLE
occ check-code compliance

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<info>
+<info xmlns:xsi= "http://www.w3.org/2001/XMLSchema-instance"
+	  xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
 	<id>user_external</id>
 	<name>External user support</name>
 	<summary>Use external user authentication methods like IMAP, SMB and FTP</summary>
@@ -7,6 +8,10 @@
 	<version>0.5.0</version>
 	<licence>agpl</licence>
 	<author>Robin Appelman</author>
+	<types>
+		<prelogin/>
+		<authentication/>
+	</types>
 	<documentation>
 		<admin>https://docs.nextcloud.com/server/15/admin_manual/configuration_user/user_auth_ftp_smb_imap.html</admin>
 	</documentation>
@@ -18,8 +23,4 @@
 	<dependencies>
 		<nextcloud min-version="15" max-version="15" />
 	</dependencies>
-	<types>
-		<authentication/>
-		<prelogin/>
-	</types>
 </info>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,22 +4,23 @@
 	<name>External user support</name>
 	<summary>Use external user authentication methods like IMAP, SMB and FTP</summary>
 	<description>Use external user authentication methods like IMAP, SMB and FTP</description>
-	<category>tools</category>
-	<category>integration</category>
-	<licence>AGPL</licence>
+	<version>0.5.0</version>
+	<licence>agpl</licence>
 	<author>Robin Appelman</author>
 	<documentation>
 		<admin>https://docs.nextcloud.com/server/15/admin_manual/configuration_user/user_auth_ftp_smb_imap.html</admin>
 	</documentation>
+	<category>tools</category>
+	<category>integration</category>
 	<website>https://github.com/nextcloud/user_external/</website>
 	<bugs>https://github.com/nextcloud/user_external/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/user_external.git</repository>
 	<dependencies>
-		<nextcloud min-version="15" max-version="15" />
+		<nextcloud min-version="13" max-version="15" />
 	</dependencies>
-	<version>0.5.0</version>
 	<types>
 		<authentication/>
 		<prelogin/>
 	</types>
+	<shipped>true</shipped>
 </info>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,11 +16,10 @@
 	<bugs>https://github.com/nextcloud/user_external/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/user_external.git</repository>
 	<dependencies>
-		<nextcloud min-version="13" max-version="15" />
+		<nextcloud min-version="15" max-version="15" />
 	</dependencies>
 	<types>
 		<authentication/>
 		<prelogin/>
 	</types>
-	<shipped>true</shipped>
 </info>

--- a/lib/base.php
+++ b/lib/base.php
@@ -55,11 +55,11 @@ abstract class Base extends \OC\User\Backend{
 	 * @return string display name
 	 */
 	public function getDisplayName($uid) {
-		$user = OC_DB::executeAudited(
+		$user = \OC::$server->getDatabaseConnection()->executeQuery(
 			'SELECT `displayname` FROM `*PREFIX*users_external`'
 			. ' WHERE `uid` = ? AND `backend` = ?',
 			array($uid, $this->backend)
-		)->fetchRow();
+		)->fetch();
 		$displayName = trim($user['displayname'], ' ');
 		if (!empty($displayName)) {
 			return $displayName;
@@ -170,11 +170,11 @@ abstract class Base extends \OC\User\Backend{
 	 * @return boolean
 	 */
 	public function userExists($uid) {
-		$result = OC_DB::executeAudited(
+		$result = \OC::$server->getDatabaseConnection()->executeQuery(
 			'SELECT COUNT(*) FROM `*PREFIX*users_external`'
 			. ' WHERE LOWER(`uid`) = LOWER(?) AND `backend` = ?',
 			array($uid, $this->backend)
 		);
-		return $result->fetchOne() > 0;
+		return $result->fetch() > 0;
 	}
 }

--- a/lib/base.php
+++ b/lib/base.php
@@ -40,7 +40,7 @@ abstract class Base extends \OC\User\Backend{
 	 * @return bool
 	 */
 	public function deleteUser($uid) {
-		OC_DB::executeAudited(
+		\OC::$server->getDatabaseConnection()->executeQuery(
 			'DELETE FROM `*PREFIX*users_external` WHERE `uid` = ? AND `backend` = ?',
 			array($uid, $this->backend)
 		);
@@ -136,7 +136,7 @@ abstract class Base extends \OC\User\Backend{
 		if (!$this->userExists($uid)) {
 			return false;
 		}
-		OC_DB::executeAudited(
+		\OC::$server->getDatabaseConnection()->executeQuery(
 			'UPDATE `*PREFIX*users_external` SET `displayname` = ?'
 			. ' WHERE LOWER(`uid`) = ? AND `backend` = ?',
 			array($displayName, $uid, $this->backend)
@@ -154,7 +154,7 @@ abstract class Base extends \OC\User\Backend{
 	protected function storeUser($uid)
 	{
 		if (!$this->userExists($uid)) {
-			OC_DB::executeAudited(
+			\OC::$server->getDatabaseConnection()->executeQuery(
 				'INSERT INTO `*PREFIX*users_external` ( `uid`, `backend` )'
 				. ' VALUES( ?, ? )',
 				array($uid, $this->backend)

--- a/lib/ftp.php
+++ b/lib/ftp.php
@@ -46,9 +46,9 @@ class OC_User_FTP extends \OCA\user_external\Base{
 	 */
 	public function checkPassword($uid, $password) {
 		if (false === array_search($this->protocol, stream_get_wrappers())) {
-			OCP\Util::writeLog(
-				'user_external',
-				'ERROR: Stream wrapper not available: ' . $this->protocol, OCP\Util::ERROR
+			OC::$server->getLogger()->error(
+				'ERROR: Stream wrapper not available: ' . $this->protocol,
+				['app' => 'user_external']
 			);
 			return false;
 		}

--- a/lib/imap.php
+++ b/lib/imap.php
@@ -65,12 +65,12 @@ class OC_User_IMAP extends \OCA\user_external\Base {
 		if(count($users) === 1) {
 			$username = $uid;
 			$uid = $users[0];
- 		// Check if we only want logins from ONE domain and strip the domain part from UID		
-		}elseif($this->domain != '') {
+ 		// Check if we only want logins from ONE domain and strip the domain part from UID
+	}elseif($this->domain !== '') {
  			$pieces = explode('@', $uid);
- 			if(count($pieces) == 1) {
+ 			if(count($pieces) === 1) {
  				$username = $uid . "@" . $this->domain;
- 			}elseif((count($pieces) == 2) and ($pieces[1] == $this->domain)) {
+ 			}elseif((count($pieces) === 2) and ($pieces[1] === $this->domain)) {
  				$username = $uid;
  				$uid = $pieces[0];
  			}else{
@@ -79,7 +79,7 @@ class OC_User_IMAP extends \OCA\user_external\Base {
  		}else{
  			$username = $uid;
  		}
- 
+
  		$mbox = @imap_open($this->mailbox, $username, $password, OP_HALFOPEN, 1);
 		imap_errors();
 		imap_alerts();

--- a/lib/imap.php
+++ b/lib/imap.php
@@ -42,7 +42,7 @@ class OC_User_IMAP extends \OCA\user_external\Base {
 	 */
 	public function checkPassword($uid, $password) {
 		if (!function_exists('imap_open')) {
-			OCP\Util::writeLog('user_external', 'ERROR: PHP imap extension is not installed', OCP\Util::ERROR);
+			OC::$server->getLogger()->error('ERROR: PHP imap extension is not installed', ['app' => 'user_external']);
 			return false;
 		}
 

--- a/lib/imap.php
+++ b/lib/imap.php
@@ -52,13 +52,13 @@ class OC_User_IMAP extends \OCA\user_external\Base {
 			$uid = str_replace("%40","@",$uid);
 		}
 
-                $result = OC_DB::executeAudited(
+                $result = \OC::$server->getDatabaseConnection()->executeQuery(
                         'SELECT `userid` FROM `*PREFIX*preferences` WHERE `appid`=? AND `configkey`=? AND `configvalue`=?',
                         array('settings','email',$uid)
                 );
 
 		$users = array();
-		while ($row = $result->fetchRow()) {
+		while ($row = $result->fetch()) {
 			$users[] = $row['userid'];
 		}
 

--- a/lib/imap.php
+++ b/lib/imap.php
@@ -52,39 +52,21 @@ class OC_User_IMAP extends \OCA\user_external\Base {
 			$uid = str_replace("%40","@",$uid);
 		}
 
-		$query = \OC::$server->getDatabaseConnection()->getQueryBuilder();
-		$query->select('userid')
-			->from('preferences')
-			->where($query->expr()->eq('appid', $query->createNamedParameter('settings')))
-			->andWhere($query->expr()->eq('configkey', $query->createNamedParameter('email')))
-			->andWhere($query->expr()->eq('configvalue', $query->createNamedParameter($uid)));
-		$result = $query->execute();
-
-		$users = [];
-		while ($row = $result->fetch()) {
-			$users[] = $row['userid'];
-		}
-		$result->closeCursor();
-
-		if(count($users) === 1) {
+		if ($this->domain !== '') {
+			$pieces = explode('@', $uid);
+			if (count($pieces) === 1) {
+				$username = $uid . '@' . $this->domain;
+			} else if(count($pieces) === 2 && $pieces[1] === $this->domain) {
+				$username = $uid;
+				$uid = $pieces[0];
+			} else {
+				return false;
+			}
+		} else {
 			$username = $uid;
-			$uid = $users[0];
- 		// Check if we only want logins from ONE domain and strip the domain part from UID
-		}elseif($this->domain !== '') {
- 			$pieces = explode('@', $uid);
- 			if(count($pieces) === 1) {
- 				$username = $uid . "@" . $this->domain;
- 			}elseif((count($pieces) === 2) && ($pieces[1] === $this->domain)) {
- 				$username = $uid;
- 				$uid = $pieces[0];
- 			}else{
- 				return false;
- 			}
- 		}else{
- 			$username = $uid;
  		}
 
- 		$mbox = @imap_open($this->mailbox, $username, $password, OP_HALFOPEN, 1);
+		$mbox = @imap_open($this->mailbox, $username, $password, OP_HALFOPEN, 1);
 		imap_errors();
 		imap_alerts();
 		if($mbox !== false) {

--- a/lib/smb.php
+++ b/lib/smb.php
@@ -53,7 +53,7 @@ class OC_User_SMB extends \OCA\user_external\Base{
 		} else if (strpos($lastline, 'NT_STATUS_BAD_NETWORK_NAME') !== false) {
 			//login on minor error
 			goto login;
-		} else if ($retval != 0) {
+		} else if ($retval !== 0) {
 			//some other error
 			OCP\Util::writeLog(
 				'user_external', 'ERROR: smbclient error: ' . trim($lastline),
@@ -91,4 +91,3 @@ class OC_User_SMB extends \OCA\user_external\Base{
 		return false;
 	}
 }
-

--- a/lib/smb.php
+++ b/lib/smb.php
@@ -42,9 +42,9 @@ class OC_User_SMB extends \OCA\user_external\Base{
 		$command = self::SMBCLIENT.' '.escapeshellarg('//' . $this->host . '/dummy').' -U'.$uidEscaped.'%'.$password;
 		$lastline = exec($command, $output, $retval);
 		if ($retval === 127) {
-			OCP\Util::writeLog(
-				'user_external', 'ERROR: smbclient executable missing',
-				OCP\Util::ERROR
+			OC::$server->getLogger()->error(
+				'ERROR: smbclient executable missing',
+				['app' => 'user_external']
 			);
 			return false;
 		} else if (strpos($lastline, self::LOGINERROR) !== false) {
@@ -55,9 +55,9 @@ class OC_User_SMB extends \OCA\user_external\Base{
 			goto login;
 		} else if ($retval !== 0) {
 			//some other error
-			OCP\Util::writeLog(
-				'user_external', 'ERROR: smbclient error: ' . trim($lastline),
-				OCP\Util::ERROR
+			OC::$server->getLogger()->error(
+				'ERROR: smbclient error: ' . trim($lastline),
+				['app' => 'user_external']
 			);
 			return false;
 		} else {

--- a/lib/webdavauth.php
+++ b/lib/webdavauth.php
@@ -28,14 +28,14 @@ class WebDavAuth extends Base {
 	public function checkPassword($uid, $password) {
 		$arr = explode('://', $this->webDavAuthUrl, 2);
 		if( ! isset($arr) OR count($arr) !== 2) {
-			\OCP\Util::writeLog('OC_USER_WEBDAVAUTH', 'Invalid Url: "'.$this->webDavAuthUrl.'" ', 3);
+			OC::$server->getLogger()->error('ERROR: Invalid WebdavUrl: "'.$this->webDavAuthUrl.'" ', ['app' => 'user_external']);
 			return false;
 		}
 		list($protocol, $path) = $arr;
 		$url= $protocol.'://'.urlencode($uid).':'.urlencode($password).'@'.$path;
 		$headers = get_headers($url);
 		if($headers === false) {
-			\OCP\Util::writeLog('OC_USER_WEBDAVAUTH', 'Not possible to connect to WebDAV Url: "'.$protocol.'://'.$path.'" ', 3);
+			OC::$server->getLogger()->error('ERROR: Not possible to connect to WebDAV Url: "'.$protocol.'://'.$path.'" ', ['app' => 'user_external']);
 			return false;
 
 		}

--- a/lib/webdavauth.php
+++ b/lib/webdavauth.php
@@ -34,7 +34,7 @@ class WebDavAuth extends Base {
 		list($protocol, $path) = $arr;
 		$url= $protocol.'://'.urlencode($uid).':'.urlencode($password).'@'.$path;
 		$headers = get_headers($url);
-		if($headers==false) {
+		if($headers === false) {
 			\OCP\Util::writeLog('OC_USER_WEBDAVAUTH', 'Not possible to connect to WebDAV Url: "'.$protocol.'://'.$path.'" ', 3);
 			return false;
 


### PR DESCRIPTION
as of #6 
- [X] change discouraged operators 
- [X] change deprecated logging method
- [x] make appinfo.xml compliant
- [x] OC_DB `static method of private class must not be called` and `private class must not be imported with a use statement`

cc @nextcloud/user_external 

1. occ check-code says for the appinfo.xml that the element `types` would not be expected. In NC12 documentation I can find `types`, in any newer version it's gone and I can't find any information with what I could replace / change this.

2. I would also need help with `OC_DB - private class must not be imported with a use statement` and `OC_DB - Static method of private class must not be called`. What has to be changed there?