### PR TITLE
Add Prosody XMPP MySQL DB authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Add the following to your `config.php`:
 
 XMPP
 ----
-Authenticate Nextcloud users against an Prosody XMPP MySQL database.
+Authenticate Nextcloud users against a Prosody XMPP MySQL database.
 Prosody user and password need to be given for the Nextcloud login
 
 

--- a/README.md
+++ b/README.md
@@ -131,3 +131,11 @@ Add the following to your `config.php`:
             'arguments' => array('https://example.com/webdav'),
         ),
     ),
+
+
+Alternatives
+------------
+Other extensions allow connecting to external user databases directly via SQL, which may be faster:
+
+* [user_sql](https://github.com/nextcloud/user_sql)
+* [user_backend_sql_raw](https://github.com/PanCakeConnaisseur/user_backend_sql_raw)

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Add the following to your `config.php`:
 
 XMPP
 ----
-Authenticate Nextcloud users against a Prosody XMPP MySQL database.
+Authenticate Nextcloud users against an Prosody XMPP MySQL database.
 Prosody user and password need to be given for the Nextcloud login
 
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,29 @@ Add the following to your `config.php`:
     ),
 
 
+XMPP
+----
+Authenticate Nextcloud users against an Prosody XMPP MySQL database.
+Prosody user and password need to be given for the Nextcloud login
+
+
+### Configuration
+Add the following to your `config.php`:
+
+    'user_backends' => array (
+        0 => array (
+            'class' => 'OC_User_XMPP',
+                'arguments' => array (
+                    0 => 'dbhost',
+                    1 => 'prosodydb',
+                    2 => 'dbuser',
+                    3 => 'dbuserpassword',
+                    4 => 'xmppdomain',
+                ),
+            ),
+    ),
+
+
 Alternatives
 ------------
 Other extensions allow connecting to external user databases directly via SQL, which may be faster:

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -2,3 +2,4 @@
 OC::$CLASSPATH['OC_User_IMAP']='user_external/lib/imap.php';
 OC::$CLASSPATH['OC_User_SMB']='user_external/lib/smb.php';
 OC::$CLASSPATH['OC_User_FTP']='user_external/lib/ftp.php';
+OC::$CLASSPATH['OC_User_FTP']='user_external/lib/xmpp.php';

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -3,8 +3,8 @@
 	  xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
 	<id>user_external</id>
 	<name>External user support</name>
-	<summary>Use external user authentication methods like IMAP, SMB and FTP</summary>
-	<description>Use external user authentication methods like IMAP, SMB and FTP</description>
+	<summary>Use external user authentication methods like IMAP, SMB, FTP and XMPP</summary>
+	<description>Use external user authentication methods like IMAP, SMB, FTP and XMPP</description>
 	<version>0.5.0</version>
 	<licence>agpl</licence>
 	<author>Robin Appelman</author>

--- a/lib/imap.php
+++ b/lib/imap.php
@@ -67,8 +67,14 @@ class OC_User_IMAP extends \OCA\user_external\Base {
  		}
 
 		$mbox = @imap_open($this->mailbox, $username, $password, OP_HALFOPEN, 1);
-		imap_errors();
-		imap_alerts();
+		OC::$server->getLogger()->error(
+			'ERROR: IMAP Error: ' . print_r(imap_errors(), true),
+			['app' => 'user_external']
+		);
+		OC::$server->getLogger()->error(
+			'ERROR: IMAP Warning: ' . print_r(imap_alerts(), true),
+			['app' => 'user_external']
+		);
 		if($mbox !== false) {
 			imap_close($mbox);
 			$uid = mb_strtolower($uid);

--- a/lib/imap.php
+++ b/lib/imap.php
@@ -69,7 +69,7 @@ class OC_User_IMAP extends \OCA\user_external\Base {
 		$mbox = @imap_open($this->mailbox, $username, $password, OP_HALFOPEN, 1);
 		$imapErrors = imap_errors();
 		$imapAlerts = imap_alerts();
-		if (!empty($imapErrors) {
+		if (!empty($imapErrors)) {
 			OC::$server->getLogger()->error(
 				'ERROR: IMAP Error: ' . print_r($imapErrors, true),
 				['app' => 'user_external']

--- a/lib/imap.php
+++ b/lib/imap.php
@@ -71,8 +71,8 @@ class OC_User_IMAP extends \OCA\user_external\Base {
 			'ERROR: IMAP Error: ' . print_r(imap_errors(), true),
 			['app' => 'user_external']
 		);
-		OC::$server->getLogger()->error(
-			'ERROR: IMAP Warning: ' . print_r(imap_alerts(), true),
+		OC::$server->getLogger()->warning(
+			'WARNING: IMAP Warning: ' . print_r(imap_alerts(), true),
 			['app' => 'user_external']
 		);
 		if($mbox !== false) {

--- a/lib/imap.php
+++ b/lib/imap.php
@@ -67,14 +67,20 @@ class OC_User_IMAP extends \OCA\user_external\Base {
  		}
 
 		$mbox = @imap_open($this->mailbox, $username, $password, OP_HALFOPEN, 1);
-		OC::$server->getLogger()->error(
-			'ERROR: IMAP Error: ' . print_r(imap_errors(), true),
-			['app' => 'user_external']
-		);
-		OC::$server->getLogger()->warning(
-			'WARNING: IMAP Warning: ' . print_r(imap_alerts(), true),
-			['app' => 'user_external']
-		);
+		$imapErrors = imap_errors();
+		$imapAlerts = imap_alerts();
+		if (!empty($imapErrors) {
+			OC::$server->getLogger()->error(
+				'ERROR: IMAP Error: ' . print_r($imapErrors, true),
+				['app' => 'user_external']
+			);
+		}
+		if (!empty($imapAlerts)) {
+			OC::$server->getLogger()->warning(
+				'WARNING: IMAP Warning: ' . print_r($imapAlerts, true),
+				['app' => 'user_external']
+			);
+		}
 		if($mbox !== false) {
 			imap_close($mbox);
 			$uid = mb_strtolower($uid);

--- a/lib/xmpp.php
+++ b/lib/xmpp.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright (c) 2019 Sebastian Sterk <sebastian@wiuwiu.de>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+/**
+ * User authentication against a XMPP Prosody MySQL database
+ *
+ * @category Apps
+ * @package  UserExternal
+ * @author   Sebastian Sterk https://wiuwiu.de/Imprint
+ * @license  http://www.gnu.org/licenses/agpl AGPL
+ */
+class OC_User_XMPP extends \OCA\user_external\Base {
+	private $host;
+	private $xmppdb;
+	private $xmppdbuser;
+	private $xmppdbpassword;
+	private $xmppdomain;
+
+	public function __construct($host, $xmppdb, $xmppdbuser, $xmppdbpassword, $xmppdomain) {
+		parent::__construct($host);
+		$this->host = $host;
+		$this->xmppdb = $xmppdb;
+		$this->xmppdbuser = $xmppdbuser;
+		$this->xmppdbpassword = $xmppdbpassword;
+		$this->xmppdomain = $xmppdomain;
+	}
+
+	public function hmac_sha1($key, $data) {
+                if (strlen($key) > 64)
+                        $key = str_pad(sha1($key, true), 64, chr(0));
+                if (strlen($key) < 64)
+                        $key = str_pad($key, 64, chr(0));
+
+                $opad = str_repeat(chr(0x5C), 64);
+                $ipad = str_repeat(chr(0x36), 64);
+
+                for ($i = 0; $i < strlen($key); $i++) {
+                        $opad[$i] = $opad[$i] ^ $key[$i];
+                        $ipad[$i] = $ipad[$i] ^ $key[$i];
+                }
+                return sha1($opad.sha1($ipad.$data, true));
+        }
+	
+	public function checkPassword($uid, $password){
+		$pdo = new PDO("mysql:host=$this->host;dbname=$this->xmppdb", $this->xmppdbuser, $this->xmppdbpassword);
+		if(isset($uid) && isset($password)) {
+        		if(!filter_var($uid, FILTER_VALIDATE_EMAIL) || !strpos($uid, $this->xmppdomain) || substr($uid, -strlen($this->xmppdomain)) != $this->xmppdomain)
+				return false;
+			$user = explode("@", $uid);
+        		$username = strtolower($user[0]);
+        		$submitted_password = $password;
+        		$statement = $pdo->prepare("SELECT * FROM prosody WHERE user = :user AND host = :xmppdomain AND store = 'accounts'");
+        		$result = $statement->execute(array('user' => $username, 'xmppdomain' => $this->xmppdomain));
+        		$user = $statement->fetchAll();
+        		if(empty($user))
+                		return false;
+        		foreach ($user as $key){
+                        	if($key[3] == "salt")
+                        	        $internal_salt = $key['value'];
+                        	if($key[3] == "server_key")
+                        	        $internal_server_key = $key['value'];
+                        	if($key[3] == "stored_key")
+                        	        $internal_stored_key = $key['value'];
+		        }
+	        	unset($user);
+		        $internal_iteration = '4096';
+
+		        $new_salted_password = hash_pbkdf2('sha1', $submitted_password, $internal_salt, $internal_iteration, 0, true);
+		        $new_server_key = $this->hmac_sha1($new_salted_password, 'Server Key');
+		        $new_client_key = $this->hmac_sha1($new_salted_password, 'Client Key');
+		        $new_stored_key = sha1(hex2bin($new_client_key));
+
+		        if ($new_server_key == $internal_server_key && $new_stored_key == $internal_stored_key){
+				$uid = mb_strtolower($uid);
+	                        $this->storeUser($uid);
+				return $uid;
+			} else
+				return false;
+		}
+	}
+}


### PR DESCRIPTION
This pull request contains an implementation for authentication against a Prosody XMPP MySQL database. The user can login to a nextcloud instance with his XMPP ID + password.