### PR TITLE
Add authentication against basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,27 @@ Add the following to your `config.php`:
     ),
 
 
+BasicAuth
+------
+
+Authenticate users by an [HTTP Basic access authentication][1]  call. 
+HTTP server of your choice to authenticate. It should return HTTP 2xx for correct credentials and an appropriate other error code for wrong ones or refused access.
+
+### Configuration
+The only supported parameter is the URL of the web server where the authentication happens.
+
+Add the following to your `config.php`:
+
+    'user_backends' => array(
+        array(
+            'class' => '\OCA\User_External\BasicAuth',
+            'arguments' => array('https://example.com/basic_auth'),
+        ),
+    ),
+
+
+[1]: https://en.wikipedia.org/wiki/Basic_access_authentication
+
 Alternatives
 ------------
 Other extensions allow connecting to external user databases directly via SQL, which may be faster:

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Add the following to your `config.php`:
 
     'user_backends' => array(
         array(
-            'class' => '\OCA\User_External\BasicAuth',
+            'class' => 'OC_User_BasicAuth',
             'arguments' => array('https://example.com/basic_auth'),
         ),
     ),

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -2,3 +2,4 @@
 OC::$CLASSPATH['OC_User_IMAP']='user_external/lib/imap.php';
 OC::$CLASSPATH['OC_User_SMB']='user_external/lib/smb.php';
 OC::$CLASSPATH['OC_User_FTP']='user_external/lib/ftp.php';
+OC::$CLASSPATH['OC_User_BasicAuth']='user_external/lib/basicauth.php';

--- a/lib/basicauth.php
+++ b/lib/basicauth.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright (c) 2019 Lutz Freitag <lutz.freitag@gottliebtfreitag.de>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+class OC_User_BasicAuth extends \OCA\user_external\Base {
+
+	private $authUrl;
+
+	public function __construct($authUrl) {
+		parent::__construct($authUrl);
+		$this->authUrl =$authUrl;
+	}
+
+	/**
+	 * Check if the password is correct without logging in the user
+	 *
+	 * @param string $uid      The username
+	 * @param string $password The password
+	 *
+	 * @return true/false
+	 */
+	public function checkPassword($uid, $password) {
+		stream_context_set_default(array(
+		  'http'=>array(
+		    'method'=>"GET",
+		    'header' => "authorization: Basic " . base64_encode("$uid:$password")
+		  ))
+		);
+		$headers = get_headers($this->authUrl);
+
+		if($headers === false) {
+			OC::$server->getLogger()->error(
+				'ERROR: Not possible to connect to BasicAuth Url: "'.$this->authUrl.'"', 
+				['app' => 'user_external']
+			);
+			return false;
+		}
+
+		$returnCode= substr($headers[0], 9, 3);
+		if(substr($returnCode, 0, 1) === '2') {
+			$this->storeUser($uid);
+			return $uid;
+		} else {
+			return false;
+		}
+	}
+}

--- a/lib/basicauth.php
+++ b/lib/basicauth.php
@@ -32,9 +32,9 @@ class OC_User_BasicAuth extends \OCA\user_external\Base {
 		);
 		$headers = get_headers($this->authUrl);
 
-		if($headers === false) {
+		if(!$headers) {
 			OC::$server->getLogger()->error(
-				'ERROR: Not possible to connect to BasicAuth Url: "'.$this->authUrl.'"', 
+				'ERROR: Not possible to connect to BasicAuth Url: '.$this->authUrl, 
 				['app' => 'user_external']
 			);
 			return false;

--- a/tests/basic_auth.php
+++ b/tests/basic_auth.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright (c) 2019 Lutz Freitag <lutz.freitag@gottliebtfreitag.de>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+class Test_User_BasicAuth extends \Test\TestCase {
+	/**
+	 * @var OC_User_BasicAuth $instance
+	 */
+	private $instance;
+
+	private function getConfig() {
+		return include(__DIR__.'/config.php');
+	}
+
+	function skip() {
+		$config=$this->getConfig();
+		$this->skipUnless($config['basic_auth']['run']);
+	}
+
+	protected function setUp() {
+		parent::setUp();
+		$config=$this->getConfig();
+		$this->instance=new OC_User_BasicAuth($config['basic_auth']['url']);
+	}
+
+	function testLogin() {
+		$config=$this->getConfig();
+		$this->assertEquals($config['basic_auth']['user'],$this->instance->checkPassword($config['basic_auth']['user'],$config['basic_auth']['password']));
+		$this->assertFalse($this->instance->checkPassword($config['basic_auth']['user'],$config['basic_auth']['password'].'foo'));
+	}
+}

--- a/tests/config.php
+++ b/tests/config.php
@@ -26,4 +26,10 @@ return array(
 		'user'=>'test',//valid username/password combination
 		'password'=>'test',
 	),
+	'basic_auth'=>array(
+		'run'=>false,
+		'url'=>'localhost/basic_auth',
+		'user'=>'test',//valid username/password combination
+		'password'=>'test',
+	),
 );


### PR DESCRIPTION
I've added code to authenticate against http basic access authentication.
In my setup I have a (self made) single sign on that can handle basic auth requests (because they are so insanely easy to implement) and use that as an identity and authentication provider.
This PR contains the code that runs on my setup.
