### PR TITLE
optional imap groups via domain & make domain striping optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Add the following to your `config.php`:
         array(
             'class' => 'OC_User_IMAP',
             'arguments' => array(
-                '127.0.0.1', 993, 'ssl', 'example.com'
+                '127.0.0.1', 993, 'ssl', 'example.com', true, false
             ),
         ),
     ),
@@ -79,9 +79,12 @@ you want to restrict the domain (4th parameter), you need to also specify
 the port (2nd parameter) and sslmode (3rd parameter; set to `null` for
 insecure connection).
 If a domain name (e.g. example.com) is specified, then this makes sure that
-only users from this domain will be allowed to login. After successfull
-login the domain part will be striped and the rest used as username in
-Nextcloud. e.g. 'username@example.com' will be 'username' in Nextcloud.
+only users from this domain will be allowed to login. If the fifth parameter
+is set to true, after successfull login the domain part will be striped and
+the rest used as username in Nextcloud. e.g. 'username@example.com' will be
+'username' in Nextcloud. The sixth parameter toggles whether on creation of
+the user, it is added to a group corresponding to the name of the domain part
+of the address. 
 
 
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -6,6 +6,7 @@
  * See the COPYING-README file.
  */
 namespace OCA\user_external;
+use \OC_DB;
 
 /**
  * Base class for external auth implementations that stores users
@@ -182,7 +183,21 @@ abstract class Base extends \OC\User\Backend{
 					'backend' => $query->createNamedParameter($this->backend),
 				]);
 			$query->execute();
+			$pieces = explode('@',$uid,2);
+			if($pieces[1]) {
+				OC_DB::executeAudited(
+					'INSERT IGNORE INTO `*PREFIX*groups` ( `gid` )'
+					. ' VALUES( ? )',
+					array($pieces[1])
+				);
+				OC_DB::executeAudited(
+					'INSERT INTO `*PREFIX*group_user` ( `gid`, `uid` )'
+					. ' VALUES( ?, ? )',
+					array($pieces[1], $uid)
+				);
+			}
 		}
+		
 	}
 
 	/**

--- a/lib/base.php
+++ b/lib/base.php
@@ -6,7 +6,6 @@
  * See the COPYING-README file.
  */
 namespace OCA\user_external;
-use \OC_DB;
 
 /**
  * Base class for external auth implementations that stores users
@@ -185,16 +184,8 @@ abstract class Base extends \OC\User\Backend{
 			$query->execute();
 			$pieces = explode('@',$uid,2);
 			if($pieces[1]) {
-				OC_DB::executeAudited(
-					'INSERT IGNORE INTO `*PREFIX*groups` ( `gid` )'
-					. ' VALUES( ? )',
-					array($pieces[1])
-				);
-				OC_DB::executeAudited(
-					'INSERT INTO `*PREFIX*group_user` ( `gid`, `uid` )'
-					. ' VALUES( ?, ? )',
-					array($pieces[1], $uid)
-				);
+				$createduser = \OC::$server->getUserManager()->get($uid);
+				\OC::$server->getGroupManager()->createGroup($pieces[1])->addUser($createduser);
 			}
 		}
 		

--- a/lib/base.php
+++ b/lib/base.php
@@ -173,10 +173,8 @@ abstract class Base extends \OC\User\Backend{
 	 *
 	 * @return void
 	 */
-	protected function storeUser($uid)
-	{
+	protected function storeUser($uid) {
 		if (!$this->userExists($uid)) {
-
 			$query = \OC::$server->getDatabaseConnection()->getQueryBuilder();
 			$query->insert('users_external')
 				->values([
@@ -184,13 +182,7 @@ abstract class Base extends \OC\User\Backend{
 					'backend' => $query->createNamedParameter($this->backend),
 				]);
 			$query->execute();
-			$pieces = explode('@',$uid,2);
-			if($pieces[1]) {
-				$createduser = \OC::$server->getUserManager()->get($uid);
-				\OC::$server->getGroupManager()->createGroup($pieces[1])->addUser($createduser);
-			}
 		}
-		
 	}
 
 	/**

--- a/lib/base.php
+++ b/lib/base.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Copyright (c) 2014 Christian Weiske <cweiske@cweiske.de>
+ * @author Jonas Sulzer <jonas@violoncello.ch>
+ * @author Christian Weiske <cweiske@cweiske.de>
+ * @copyright (c) 2014 Christian Weiske <cweiske@cweiske.de>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.

--- a/lib/base.php
+++ b/lib/base.php
@@ -170,10 +170,11 @@ abstract class Base extends \OC\User\Backend{
 	 * Create user record in database
 	 *
 	 * @param string $uid The username
+	 * @param array $groups Groups to add the user to on creation
 	 *
 	 * @return void
 	 */
-	protected function storeUser($uid) {
+	protected function storeUser($uid, $groups) {
 		if (!$this->userExists($uid)) {
 			$query = \OC::$server->getDatabaseConnection()->getQueryBuilder();
 			$query->insert('users_external')
@@ -182,6 +183,13 @@ abstract class Base extends \OC\User\Backend{
 					'backend' => $query->createNamedParameter($this->backend),
 				]);
 			$query->execute();
+
+			if ($groups) {
+				$createduser = \OC::$server->getUserManager()->get($uid);
+				foreach ($groups as $group) {
+					\OC::$server->getGroupManager()->createGroup($group)->addUser($createduser);
+				}
+			}
 		}
 	}
 

--- a/lib/imap.php
+++ b/lib/imap.php
@@ -109,7 +109,7 @@ class OC_User_IMAP extends \OCA\user_external\Base {
 				]);
 			$query->execute();
 
-			if($groupDomain && $group) {
+			if($this->groupDomain && $group) {
 				$createduser = \OC::$server->getUserManager()->get($uid);
 				\OC::$server->getGroupManager()->createGroup($group)->addUser($createduser);
 			}

--- a/lib/imap.php
+++ b/lib/imap.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Copyright (c) 2012 Robin Appelman <icewind@owncloud.com>
+ * @author Robin Appelman <icewind@owncloud.com>
+ * @author Jonas Sulzer <jonas@violoncello.ch>
+ * @copyright (c) 2012 Robin Appelman <icewind@owncloud.com>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.


### PR DESCRIPTION
imap groups via domain-part
for #10 working with v15 from https://github.com/nextcloud/apps/compare/master...bjoern86:patch-1
- [X] if someone can convert it to new way "$query->insert..."

Changes proposed in this pull request:
- if there is no group equal to domain part of the new user create group
- add new user to the group
- make group and domain striping configurable via parameters

fixes #10 
fixes #76
fixes #68