### PR TITLE
Cleanly close imap connection

### DIFF
--- a/lib/imap.php
+++ b/lib/imap.php
@@ -83,6 +83,7 @@ class OC_User_IMAP extends \OCA\user_external\Base {
 		);
 
 		if($canconnect) {
+			$rcube->closeConnection();
 			$uid = mb_strtolower($uid);
 			$this->storeUser($uid);
 			return $uid;


### PR DESCRIPTION
I'm using user_external together with imapproxy (imapproxy.org) which always logged 'IMAP_Line_Read(): connection closed prematurely.' regularly, because user_external doesn't close imap connection cleanly.