### PR TITLE
Fix Querybuilder to find Users that have difference uid from displayName

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -84,7 +84,7 @@ abstract class Base extends \OC\User\Backend{
 		$query->select('uid', 'displayname')
 			->from('users_external')
 			->where($query->expr()->iLike('displayname', $query->createNamedParameter('%' . $connection->escapeLikeParameter($search) . '%')))
-			->andWhere($query->expr()->iLike('uid', $query->createNamedParameter('%' . $connection->escapeLikeParameter($search) . '%')))
+			->orWhere($query->expr()->iLike('uid', $query->createNamedParameter('%' . $connection->escapeLikeParameter($search) . '%')))
 			->andWhere($query->expr()->eq('backend', $query->createNamedParameter($this->backend)));
 		if ($limit) {
 			$query->setMaxResults($limit);


### PR DESCRIPTION
<!--
Thank you for contributing to nextcloud's user_external app!
Plases make sure to sign-off on your commits - see https://github.com/nextcloud/server/blob/master/.github/CONTRIBUTING.md#sign-your-work
-->

Fixes #73
Fixes #77
