### PR TITLE
Cleanly close imap connection

### DIFF
--- a/lib/imap.php
+++ b/lib/imap.php
@@ -83,6 +83,7 @@ class OC_User_IMAP extends \OCA\user_external\Base {
 		);
 
 		if($canconnect) {
+ 			$rcube->closeConnection();
 			$uid = mb_strtolower($uid);
 			$this->storeUser($uid);
 			return $uid;


### PR DESCRIPTION
Signed-off-by: Sebastian <bash2@momou.ch>

When using user_external over imap with imapproxy (imapproxy.org) there are a lot of 'IMAP_Line_Read(): connection closed prematurely.' messages, because user_external doesn't close imap connection cleanly.

Changes proposed in this pull request:
 - Cleanly close imap connection