### PR TITLE
Added a check to make sure BasicAuth points to a protected URL.

### DIFF
--- a/lib/basicauth.php
+++ b/lib/basicauth.php
@@ -24,6 +24,30 @@ class OC_User_BasicAuth extends \OCA\user_external\Base {
 	 * @return true/false
 	 */
 	public function checkPassword($uid, $password) {
+		/*
+		 * Connect without user/name password to make sure
+		 * URL is indeed authenticating or not...
+		 */
+		stream_context_set_default(array(
+		  'http'=>array(
+		    'method'=>"GET",
+		  ))
+		);
+		$headers = get_headers($this->authUrl, 1);
+		if(!$headers) {
+			OC::$server->getLogger()->error(
+				'ERROR: Not possible to connect to BasicAuth Url: '.$this->authUrl,
+				['app' => 'user_external']
+			);
+			return false;
+		}
+		if (!isset($headers['WWW-Authenticate'])) {
+			OC::$server->getLogger()->error(
+				'ERROR: Mis-configured BasicAuth Url: '.$this->authUrl,
+				['app' => 'user_external']
+			return false;
+		}
+
 		stream_context_set_default(array(
 		  'http'=>array(
 		    'method'=>"GET",


### PR DESCRIPTION
Fixes #58 

Changes proposed in this pull request:
 - checks the the BasicAuth URL without credentials to make sure that the backend server
   is performing authentications.

In a modern environment, the performance hit is minimal as the backend server is only queried
on a new session login.  Afterwards the backend server is not being queried until the session
logs out.