### PR TITLE
Fix Issue #56: Undefined Indices in Logs

### DIFF
--- a/lib/imap.php
+++ b/lib/imap.php
@@ -86,9 +86,8 @@ class OC_User_IMAP extends \OCA\user_external\Base {
 
 		$params = ["port"=>$this->port, "timeout"=>10];
 
-		if ($this->sslmode !== null){
-			$params["ssl_mode"] = $this->sslmode;
-		}
+		$params["ssl_mode"] = $this->sslmode ? $this->sslmode : null;
+		$params["force_caps"] = false;
 		$canconnect = $rcube->connect(
 					$this->mailbox,
 					$username,

--- a/lib/imap/imap_rcube.changes2upstream
+++ b/lib/imap/imap_rcube.changes2upstream
@@ -1,0 +1,24 @@
+commit 97dc6583c41605beda7eced3ba05fc578cfd6111
+Author: Scott Shambarger <devel@shambarger.net>
+Date:   Wed May 29 20:07:18 2019 -0700
+
+    Fix Issue #56: Undefined Indices in Logs
+
+    Add ssl_mode and force_caps to connection params, and correctly handle
+    AUTHENTICATE PLAIN in putLineC to reduce warnings in logs.
+
+    Signed-off-by: Scott Shambarger <devel@shambarger.net>
+
+diff --git a/lib/imap/imap_rcube.php b/lib/imap/imap_rcube.php
+index f5b5b79..ceec1e5 100644
+--- a/lib/imap/imap_rcube.php
++++ b/lib/imap/imap_rcube.php
+@@ -146,7 +146,7 @@ class imap_rcube
+         $res = 0;
+         if ($parts = preg_split('/(\{[0-9]+\}\r\n)/m', $string, -1, PREG_SPLIT_DELIM_CAPTURE)) {
+             for ($i=0, $cnt=count($parts); $i<$cnt; $i++) {
+-                if (preg_match('/^\{([0-9]+)\}\r\n$/', $parts[$i+1], $matches)) {
++                if (isset($parts[$i+1]) && preg_match('/^\{([0-9]+)\}\r\n$/', $parts[$i+1], $matches)) {
+                     // LITERAL+ support
+                     if ($this->prefs['literal+']) {
+                         $parts[$i+1] = sprintf("{%d+}\r\n", $matches[1]);

--- a/lib/imap/imap_rcube.php
+++ b/lib/imap/imap_rcube.php
@@ -146,7 +146,7 @@ class imap_rcube
         $res = 0;
         if ($parts = preg_split('/(\{[0-9]+\}\r\n)/m', $string, -1, PREG_SPLIT_DELIM_CAPTURE)) {
             for ($i=0, $cnt=count($parts); $i<$cnt; $i++) {
-                if (preg_match('/^\{([0-9]+)\}\r\n$/', $parts[$i+1], $matches)) {
+                if (isset($parts[$i+1]) && preg_match('/^\{([0-9]+)\}\r\n$/', $parts[$i+1], $matches)) {
                     // LITERAL+ support
                     if ($this->prefs['literal+']) {
                         $parts[$i+1] = sprintf("{%d+}\r\n", $matches[1]);


### PR DESCRIPTION
Add ssl_mode and force_caps to connection params, and correctly handle
AUTHENTICATE PLAIN in putLineC to reduce warnings in logs.

Signed-off-by: Scott Shambarger <devel@shambarger.net>

<!--
Thank you for contributing to nextcloud's user_external app!
Plases make sure to sign-off on your commits - see https://github.com/nextcloud/server/blob/master/.github/CONTRIBUTING.md#sign-your-work
-->

Fixes #56 
