### PR TITLE
Fixed SMB Login Issues

### DIFF
--- a/lib/smb.php
+++ b/lib/smb.php
@@ -39,7 +39,7 @@ class OC_User_SMB extends \OCA\user_external\Base{
 	private function tryAuthentication($uid, $password) {
 		$uidEscaped = escapeshellarg($uid);
 		$password = escapeshellarg($password);
-		$command = self::SMBCLIENT.' '.escapeshellarg('//' . $this->host . '/dummy').' -U'.$uidEscaped.'%'.$password;
+		$command = self::SMBCLIENT.' '.escapeshellarg('//' . $this->host . '/dummy').' -U '.$uidEscaped.'%'.$password;
 		$lastline = exec($command, $output, $retval);
 		if ($retval === 127) {
 			OC::$server->getLogger()->error(


### PR DESCRIPTION
**Fixes:**
We had problems with logging in some users over SMB. The error:
The first, expected to be "incorrect", login try was successful. (Because of a bad formatting in the smbclient command.) I've added the needed space after the `-U` argument.

**Additional changes:**
I rewrote the multiple `if`/`elseif`/`else`'s & `goto`'s to a easier to maintain/more professional version. (one if + switch)

**Further Proposals:**
Re-evaluate if the `NT_STATUS_BAD_NETWORK_NAME` catch is really needed or at least add a check for successful login, instead of assuming the login was successful on that error.