### PR TITLE
Regression.

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -1,7 +1,7 @@
 <?php
-OC::$CLASSPATH['OC_User_IMAP']='user_external/lib/imap.php';
-OC::$CLASSPATH['OC_User_SMB']='user_external/lib/smb.php';
-OC::$CLASSPATH['OC_User_FTP']='user_external/lib/ftp.php';
-OC::$CLASSPATH['OC_User_BasicAuth']='user_external/lib/basicauth.php';
-OC::$CLASSPATH['OC_User_SSH']='user_external/lib/ssh.php';
-OC::$CLASSPATH['OC_User_XMPP']='user_external/lib/xmpp.php';
+include_once(__DIR__ . '/../lib/imap.php');
+include_once(__DIR__ . '/../lib/smb.php');
+include_once(__DIR__ . '/../lib/ftp.php');
+include_once(__DIR__ . '/../lib/basicauth.php');
+include_once(__DIR__ . '/../lib/ssh.php');
+include_once(__DIR__ . '/../lib/xmpp.php');


### PR DESCRIPTION
When using nextcloud 17.0.2, the libraries cannot be found and an error occurs:
 User backend OC_User_[Backend] not found
Actually, this is a regression:
See: https://github.com/owncloud/user_external/pull/12/commits/c1bddb2e183312e4e491dc70536a65524fcebc04

Tested using version nextcloud 17.0.2


Fixes#
Regression  User backend OC_User_[Backend] not found nextcloud version 17.0.2

 -
 -
 - 
