### PR TITLE
DOC: added a hint/warning for upgrading from <0.6.0 and a general warning for unique uids

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ their configured display name.
 
 If something does not work, check the log file at `nextcloud/data/nextcloud.log`.
 
+**⚠⚠ Warning:** If you are using more than one backend or especially one backend more often than once, make sure that you still have resp. get unique `uid`s in the database. ⚠⚠
+
 
 FTP
 ---
@@ -86,6 +88,7 @@ the rest used as username in Nextcloud. e.g. 'username@example.com' will be
 the user, it is added to a group corresponding to the name of the domain part
 of the address. 
 
+**⚠⚠ Warning:** If you are [**upgrading** from versions **<0.6.0**](https://github.com/nextcloud/user_external/releases/tag/v0.6.0), beside adapting your `config.php` you also have to change the `backend` column in the `users_external` table of the database. In your pre 0.6.0 database it may look like `{127.0.0.1:993/imap/ssl/readonly}INBOX` or similar, but now it has to be just `127.0.0.1` for everything to work flawless again. ⚠⚠
 
 
 Samba


### PR DESCRIPTION
- finally i added a hint/warning for upgrading from <0.6.0 to manually rework the database according to https://github.com/nextcloud/user_external/issues/64#issuecomment-483224020 since it is the clearest statement i found about this topic (and it seems to work for a bunch of other guys and myself).
since there is no other doc or wiki i added it directly to the IMAP part of the main readme... anywhere else it would be pretty useless.
maybe it is enough to close #64...?

- additionally added a general warning to make sure to have unique `uid`s.