### PR TITLE
Additional authentication method for user_external: External REST API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ You need to have `php-curl` installed to use this authentication method.
  * To use this method, you need to implement a single REST endpoint:
     * Path: /_nextcloud/user_external/v1/authenticate
     * Method: POST
-    * Body as JSON UTF-8:
+    * Body as JSON UTF8:
 
 
     {

--- a/README.md
+++ b/README.md
@@ -242,8 +242,8 @@ You need to have `php-curl` installed to use this authentication method.
     * Path: /_nextcloud/user_external/v1/authenticate
     * Method: POST
     * Body as JSON UTF-8:
- 
-    
+
+
     {
        "user": {
            "id": "UserID",
@@ -252,8 +252,8 @@ You need to have `php-curl` installed to use this authentication method.
     }
  
  * If the transmitted credentials are correct, your JSON answer should be:
- 
- 
+
+
     {
         "auth": {
             "success": true,
@@ -265,14 +265,13 @@ You need to have `php-curl` installed to use this authentication method.
 
 * If the Authentication fails, your JSON answer should be:
 
-    
+
     {
         "auth": {
             "success": false
         }
     }
- 
- 
+
 Alternatives
 ------------
 Other extensions allow connecting to external user databases directly via SQL, which may be faster:

--- a/README.md
+++ b/README.md
@@ -222,56 +222,53 @@ Authenticate Nextcloud users against a REST JSON authentication API.
 The parameters are `URL, alwaysAssignDisplayname`. If you set the last parameter to `true`, the display name of the user will be replaced *each* time the users performs a login. 
 
 Add the following to your `config.php`:
-
-    'user_backends' => array (
-        0 => array (
-            'class' => 'OC_User_REST',
-                'arguments' => array (
-                    0 => 'https://URLofyourRESTserver',
-                    1 => false
-                ),
-            ),
+```
+'user_backends' => array (
+    0 => array (
+        'class' => 'OC_User_REST',
+        'arguments' => array (
+            0 => 'https://URLofyourRESTserver',
+            1 => false
+        ),
     ),
-
+),
+```
 ### Dependencies
 You need to have `php-curl` installed to use this authentication method.
 
 ### REST endpoints
- * This script perfoms an authentication via a POST JSON REST Request.
- * To use this method, you need to implement a single REST endpoint:
-    * Path: /_nextcloud/user_external/v1/authenticate
-    * Method: POST
-    * Body as JSON UTF8:
-
-
-    {
-       "user": {
-           "id": "UserID",
-           "password": "enteredPassword"
-       }
-    }
- 
+* This script perfoms an authentication via a POST JSON REST Request.
+* To use this method, you need to implement a single REST endpoint:
+   * Path: /_nextcloud/user_external/v1/authenticate
+   * Method: POST
+   * Body as JSON UTF8:
+```
+{
+   "user": {
+       "id": "UserID",
+       "password": "enteredPassword"
+   }
+}
+``` 
  * If the transmitted credentials are correct, your JSON answer should be:
-
-
-    {
-        "auth": {
-            "success": true,
-            "id": "UserID",
-            "displayName": "Display Name to Store",
-            "groups": ["group1","group2"]
-        }
+```
+{
+    "auth": {
+        "success": true,
+        "id": "UserID",
+        "displayName": "Display Name to Store",
+        "groups": ["group1","group2"]
     }
-
+}
+```
 * If the Authentication fails, your JSON answer should be:
-
-
-    {
-        "auth": {
-            "success": false
-        }
+```
+{
+    "auth": {
+        "success": false
     }
-
+}
+```
 Alternatives
 ------------
 Other extensions allow connecting to external user databases directly via SQL, which may be faster:

--- a/README.md
+++ b/README.md
@@ -214,7 +214,65 @@ Add the following to your `config.php`:
 
 **⚠⚠ Warning:** If you need to set *5 (Hashed Password in Database)* to false, your Prosody Instance is storing passwords in plaintext. This is insecure and not recommended. We highly recommend that you change your Prosody configuration to protect the passwords of your Prosody users. ⚠⚠
 
+REST
+----
+Authenticate Nextcloud users against a REST JSON authentication API. 
 
+### Configuration
+The parameters are `URL, alwaysAssignDisplayname`. If you set the last parameter to `true`, the display name of the user will be replaced *each* time the users performs a login. 
+
+Add the following to your `config.php`:
+
+    'user_backends' => array (
+        0 => array (
+            'class' => 'OC_User_REST',
+                'arguments' => array (
+                    0 => 'https://URLofyourRESTserver',
+                    1 => false
+                ),
+            ),
+    ),
+
+### Dependencies
+You need to have `php-curl` installed to use this authentication method.
+
+### REST endpoints
+ * This script perfoms an authentication via a POST JSON REST Request.
+ * To use this method, you need to implement a single REST endpoint:
+    * Path: /_nextcloud/user_external/v1/authenticate
+    * Method: POST
+    * Body as JSON UTF-8:
+ 
+    
+    {
+       "user": {
+           "id": "UserID",
+           "password": "enteredPassword"
+       }
+    }
+ 
+ * If the transmitted credentials are correct, your JSON answer should be:
+ 
+ 
+    {
+        "auth": {
+            "success": true,
+            "id": "UserID",
+            "displayName": "Display Name to Store",
+            "groups": ["group1","group2"]
+        }
+    }
+
+* If the Authentication fails, your JSON answer should be:
+
+    
+    {
+        "auth": {
+            "success": false
+        }
+    }
+ 
+ 
 Alternatives
 ------------
 Other extensions allow connecting to external user databases directly via SQL, which may be faster:

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -5,3 +5,4 @@ OC::$CLASSPATH['OC_User_FTP']='user_external/lib/ftp.php';
 OC::$CLASSPATH['OC_User_BasicAuth']='user_external/lib/basicauth.php';
 OC::$CLASSPATH['OC_User_SSH']='user_external/lib/ssh.php';
 OC::$CLASSPATH['OC_User_XMPP']='user_external/lib/xmpp.php';
+OC::$CLASSPATH['OC_User_REST']='user_external/lib/rest.php';

--- a/lib/rest.php
+++ b/lib/rest.php
@@ -84,7 +84,7 @@ class OC_User_REST extends \OCA\user_external\Base {
             if($result['auth']['success']===true) {
                 $user_exists = $this->userExists($result['auth']['id']);
                 $this->storeUser($result['auth']['id'],$result['auth']['groups']);
-                if(($user_exists && $this->alwaysAssignDisplayname) || (!$user_exists)) {
+                if(key_exists("displayName",$result['auth']) && (($user_exists && $this->alwaysAssignDisplayname) || (!$user_exists))) {
                     $this->setDisplayName($result['auth']['id'],$result['auth']['displayName']);
                 }
                 return $result['auth']['id'];
@@ -97,5 +97,6 @@ class OC_User_REST extends \OCA\user_external\Base {
                 ['app' => 'user_external']
             );
         }
+        return false;
 	}
 }

--- a/lib/rest.php
+++ b/lib/rest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Copyright (c) 2020 Michael Schindler <mich.schindl@gmail.com>
+ * Copyright (c) 2019 Lutz Freitag <lutz.freitag@gottliebtfreitag.de>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+
+/**
+ * This script perfoms an authentication via a POST JSON REST Request.
+ * To use this method, you need to implement a single REST endpoint:
+ * Path: /_nextcloud/user_external/v1/authenticate
+ * Method: POST
+ * Body as JSON UTF-8:
+ *
+ * {
+ *      "user": {
+ *          "id": "UserID",
+ *          "password": "enteredPassword"
+ *      }
+ * }
+ *
+ * If the transmitted credentials are correct, your JSON answer should be:
+ *
+ * {
+ *      "auth": {
+ *          "success": true,
+ *          "id": "UserID",
+ *          "displayName": "Display Name to Store",
+ *          "groups": ["group1","group2"]
+ *      }
+ * }
+ *
+ * If the Authentication fails, your JSON answer should be:
+ *
+ * {
+ *      "auth": {
+ *          "success": false
+ *      }
+ * }
+ *
+ */
+
+class OC_User_REST extends \OCA\user_external\Base {
+
+	private $authUrl;
+	private $alwaysAssignDisplayname;
+
+	public function __construct($authUrl,$alwaysAssignDisplayname) {
+		parent::__construct($authUrl,$alwaysAssignDisplayname);
+		$this->authUrl = $authUrl;
+		$this->alwaysAssignDisplayname = $alwaysAssignDisplayname;
+	}
+
+	/**
+	 * Check if the password is correct without logging in the user
+	 *
+	 * @param string $uid      The username
+	 * @param string $password The password
+	 *
+	 * @return true/false
+	 */
+	public function checkPassword($uid, $password) {
+		$postdata = json_encode(array("user"=>array("id"=>$uid,"password"=>$password)));
+		$ch = curl_init();
+		$headers = ['Content-Type: application/json'];
+		curl_setopt($ch,CURLOPT_URL,$this->authUrl."/_nextcloud/user_external/v1/authenticate");
+		curl_setopt($ch, CURLOPT_POST, true);
+		curl_setopt($ch, CURLOPT_POSTFIELDS, $postdata);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($ch, CURLOPT_HTTPHEADER,$headers);
+		$result = curl_exec($ch);
+		$statusCode = curl_getinfo($ch,CURLINFO_RESPONSE_CODE);
+
+        $result = json_decode($result,true);
+        if($statusCode=="404") {
+            OC::$server->getLogger()->error(
+                'ERROR: REST Server sent 404 on: '.$this->authUrl,
+                ['app' => 'user_external']
+            );
+        } elseif(is_array($result)) {
+            if($result['auth']['success']===true) {
+                $user_exists = $this->userExists($result['auth']['id']);
+                $this->storeUser($result['auth']['id'],$result['auth']['groups']);
+                if(($user_exists && $this->alwaysAssignDisplayname) || (!$user_exists)) {
+                    $this->setDisplayName($result['auth']['id'],$result['auth']['displayName']);
+                }
+                return $result['auth']['id'];
+            } else {
+                return false;
+            }
+        } elseif($result===false) {
+            OC::$server->getLogger()->error(
+                'ERROR: Not possible to connect to REST Url: '.$this->authUrl,
+                ['app' => 'user_external']
+            );
+        }
+	}
+}


### PR DESCRIPTION
Additional authentication method for user_external: External REST API.
Allows external definition von multiple groups and setting the display name once or every login (chosen by setting).

Signed-off-by: Michael Schindler <mich.schindl@gmail.com>

Changes proposed in this pull request:
 - Additional extend of user_external\Base (rest.php)
 - Reference in app.php
 - Info about using the method in README
