### PR TITLE
Adding authentication via JSON REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,61 @@ Add the following to your `config.php`:
 
 **⚠⚠ Warning:** If you need to set *5 (Hashed Password in Database)* to false, your Prosody Instance is storing passwords in plaintext. This is insecure and not recommended. We highly recommend that you change your Prosody configuration to protect the passwords of your Prosody users. ⚠⚠
 
+REST
+----
+Authenticate Nextcloud users against a REST JSON authentication API. 
 
+### Configuration
+The parameters are `URL, alwaysAssignDisplayname`. If you set the last parameter to `true`, the display name of the user will be replaced *each* time the users performs a login. 
+
+Add the following to your `config.php`:
+```
+'user_backends' => array (
+    0 => array (
+        'class' => 'OC_User_REST',
+        'arguments' => array (
+            0 => 'https://URLofyourRESTserver',
+            1 => false
+        ),
+    ),
+),
+```
+### Dependencies
+You need to have `php-curl` installed to use this authentication method.
+
+### REST endpoints
+* This script perfoms an authentication via a POST JSON REST Request.
+* To use this method, you need to implement a single REST endpoint:
+   * Path: /_nextcloud/user_external/v1/authenticate
+   * Method: POST
+   * Body as JSON UTF8:
+```
+{
+   "user": {
+       "id": "UserID",
+       "password": "enteredPassword"
+   }
+}
+``` 
+ * If the transmitted credentials are correct, your JSON answer should be:
+```
+{
+    "auth": {
+        "success": true,
+        "id": "UserID",
+        "displayName": "Display Name to Store",
+        "groups": ["group1","group2"]
+    }
+}
+```
+* If the Authentication fails, your JSON answer should be:
+```
+{
+    "auth": {
+        "success": false
+    }
+}
+```
 Alternatives
 ------------
 Other extensions allow connecting to external user databases directly via SQL, which may be faster:

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -5,3 +5,4 @@ OC::$CLASSPATH['OC_User_FTP']='user_external/lib/ftp.php';
 OC::$CLASSPATH['OC_User_BasicAuth']='user_external/lib/basicauth.php';
 OC::$CLASSPATH['OC_User_SSH']='user_external/lib/ssh.php';
 OC::$CLASSPATH['OC_User_XMPP']='user_external/lib/xmpp.php';
+OC::$CLASSPATH['OC_User_REST']='user_external/lib/rest.php';

--- a/lib/rest.php
+++ b/lib/rest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Copyright (c) 2020 Michael Schindler <mich.schindl@gmail.com>
+ * Copyright (c) 2019 Lutz Freitag <lutz.freitag@gottliebtfreitag.de>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+
+/**
+ * This script perfoms an authentication via a POST JSON REST Request.
+ * To use this method, you need to implement a single REST endpoint:
+ * Path: /_nextcloud/user_external/v1/authenticate
+ * Method: POST
+ * Body as JSON UTF-8:
+ *
+ * {
+ *      "user": {
+ *          "id": "UserID",
+ *          "password": "enteredPassword"
+ *      }
+ * }
+ *
+ * If the transmitted credentials are correct, your JSON answer should be:
+ *
+ * {
+ *      "auth": {
+ *          "success": true,
+ *          "id": "UserID",
+ *          "displayName": "Display Name to Store",
+ *          "groups": ["group1","group2"]
+ *      }
+ * }
+ *
+ * If the Authentication fails, your JSON answer should be:
+ *
+ * {
+ *      "auth": {
+ *          "success": false
+ *      }
+ * }
+ *
+ */
+
+class OC_User_REST extends \OCA\user_external\Base {
+
+	private $authUrl;
+	private $alwaysAssignDisplayname;
+
+	public function __construct($authUrl,$alwaysAssignDisplayname) {
+		parent::__construct($authUrl,$alwaysAssignDisplayname);
+		$this->authUrl = $authUrl;
+		$this->alwaysAssignDisplayname = $alwaysAssignDisplayname;
+	}
+
+	/**
+	 * Check if the password is correct without logging in the user
+	 *
+	 * @param string $uid      The username
+	 * @param string $password The password
+	 *
+	 * @return true/false
+	 */
+	public function checkPassword($uid, $password) {
+		$postdata = json_encode(array("user"=>array("id"=>$uid,"password"=>$password)));
+		$ch = curl_init();
+		$headers = ['Content-Type: application/json'];
+		curl_setopt($ch,CURLOPT_URL,$this->authUrl."/_nextcloud/user_external/v1/authenticate");
+		curl_setopt($ch, CURLOPT_POST, true);
+		curl_setopt($ch, CURLOPT_POSTFIELDS, $postdata);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($ch, CURLOPT_HTTPHEADER,$headers);
+		$result = curl_exec($ch);
+		$statusCode = curl_getinfo($ch,CURLINFO_RESPONSE_CODE);
+
+        $result = json_decode($result,true);
+        if($statusCode==="404") {
+            OC::$server->getLogger()->error(
+                'ERROR: REST Server sent 404 on: '.$this->authUrl,
+                ['app' => 'user_external']
+            );
+        } elseif(is_array($result)) {
+            if($result['auth']['success']===true) {
+                $user_exists = $this->userExists($result['auth']['id']);
+                $this->storeUser($result['auth']['id'],$result['auth']['groups']);
+                if(key_exists("displayName",$result['auth']) && (($user_exists && $this->alwaysAssignDisplayname) || (!$user_exists))) {
+                    $this->setDisplayName($result['auth']['id'],$result['auth']['displayName']);
+                }
+                return $result['auth']['id'];
+            } else {
+                return false;
+            }
+        } elseif($result===false) {
+            OC::$server->getLogger()->error(
+                'ERROR: Not possible to connect to REST Url: '.$this->authUrl,
+                ['app' => 'user_external']
+            );
+        }
+        return false;
+	}
+}

--- a/lib/rest.php
+++ b/lib/rest.php
@@ -43,6 +43,8 @@
  *
  */
 
+use OCP\AppFramework\Http;
+
 class OC_User_REST extends \OCA\user_external\Base {
 
 	private $authUrl;
@@ -60,27 +62,40 @@ class OC_User_REST extends \OCA\user_external\Base {
 	 * @param string $uid      The username
 	 * @param string $password The password
 	 *
-	 * @return true/false
+	 * @return string $uid      The username
 	 */
 	public function checkPassword($uid, $password) {
 		$postdata = json_encode(array("user"=>array("id"=>$uid,"password"=>$password)));
-		$ch = curl_init();
-		$headers = ['Content-Type: application/json'];
-		curl_setopt($ch,CURLOPT_URL,$this->authUrl."/_nextcloud/user_external/v1/authenticate");
-		curl_setopt($ch, CURLOPT_POST, true);
-		curl_setopt($ch, CURLOPT_POSTFIELDS, $postdata);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_HTTPHEADER,$headers);
-		$result = curl_exec($ch);
-		$statusCode = curl_getinfo($ch,CURLINFO_RESPONSE_CODE);
 
-        $result = json_decode($result,true);
-        if($statusCode==="404") {
-            OC::$server->getLogger()->error(
-                'ERROR: REST Server sent 404 on: '.$this->authUrl,
-                ['app' => 'user_external']
-            );
-        } elseif(is_array($result)) {
+		$client = \OC::$server->getHTTPClientService()->newClient();
+		try {
+		    $response = $client->post($this->authUrl."/_nextcloud/user_external/v1/authenticate", [
+		       'body' => $postdata,
+               'timeout' => 10,
+               'connect_timeout' => 10,
+            ]);
+            $result = json_decode($response->getBody(),true);
+        } catch (\GuzzleHttp\Exception\RequestException $e) {
+		    if($e->getCode() === Http::STATUS_UNAUTHORIZED || $e->getCode() === Http::STATUS_FORBIDDEN) {
+                OC::$server->getLogger()->error(
+                    'ERROR: Resource on REST server is forbidden on: '.$this->authUrl,
+                    ['app' => 'user_external']
+                );
+            } elseif($e->getCode() === Http::STATUS_NOT_FOUND) {
+                OC::$server->getLogger()->error(
+                    'ERROR: REST Server sent 404 on: '.$this->authUrl,
+                    ['app' => 'user_external']
+                );
+            } else {
+                OC::$server->getLogger()->error(
+                    'ERROR: Unknown request error on: '.$this->authUrl,
+                    ['app' => 'user_external']
+                );
+            }
+		    $result = false;
+        }
+
+        if(is_array($result)) {
             if($result['auth']['success']===true) {
                 $user_exists = $this->userExists($result['auth']['id']);
                 $uid = $this->storeUser($result['auth']['id'],$result['auth']['groups']);

--- a/lib/rest.php
+++ b/lib/rest.php
@@ -83,11 +83,12 @@ class OC_User_REST extends \OCA\user_external\Base {
         } elseif(is_array($result)) {
             if($result['auth']['success']===true) {
                 $user_exists = $this->userExists($result['auth']['id']);
-                $this->storeUser($result['auth']['id'],$result['auth']['groups']);
+                $uid = $this->storeUser($result['auth']['id'],$result['auth']['groups']);
                 if(key_exists("displayName",$result['auth']) && (($user_exists && $this->alwaysAssignDisplayname) || (!$user_exists))) {
                     $this->setDisplayName($result['auth']['id'],$result['auth']['displayName']);
                 }
-                return $result['auth']['id'];
+                //return $result['auth']['id'];
+                return $uid;
             } else {
                 return false;
             }


### PR DESCRIPTION
<!--
Thank you for contributing to nextcloud's user_external app!
Plases make sure to sign-off on your commits - see https://github.com/nextcloud/server/blob/master/.github/CONTRIBUTING.md#sign-your-work
-->

Changes proposed in this pull request:
 - adding REST JSON API for external user authentication:
 - checks REST endpoint and gets optional and additional user data like groups and displayname
