### PR TITLE
fix long imap login delay on mailboxes with many folders

### DIFF
--- a/lib/imap.php
+++ b/lib/imap.php
@@ -95,6 +95,7 @@ class OC_User_IMAP extends \OCA\user_external\Base {
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_USERPWD, $username.":".$password);
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'CAPABILITY');
 
 		$canconnect = curl_exec($ch);
 


### PR DESCRIPTION
<!--
Thank you for contributing to nextcloud's user_external app!
Plases make sure to sign-off on your commits - see https://github.com/nextcloud/server/blob/master/.github/CONTRIBUTING.md#sign-your-work
-->

Fixes #145 

Changes proposed in this pull request:
 - just check imap server capabiities instead of pulling the complete folder list
 