### PR TITLE
Support for custom authorization header and skip canary check

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,12 @@ BasicAuth
 
 Authenticate users by an [HTTP Basic access authentication][BasicAuth_0]  call.
 HTTP server of your choice to authenticate. It should return HTTP 2xx for correct credentials and an appropriate other error code for wrong ones or refused access.
-The HTTP server _must_ respond to any requests to the target URL with the "www-authenticate" header set. 
+By default, the HTTP server _must_ respond to any requests to the target URL with the "www-authenticate" header set. 
 Otherwise BasicAuth considers itself to be misconfigured or the HTTP server unfit for authentication.
+This check can be disabled by passing `true` as the third-argument.
 
 ### Configuration
-The only supported parameter is the URL of the web server where the authentication happens.
+The only mandatory parameter is the URL of the web server where the authentication happens. In addition, there are two optional parameters to configure the authorization header name (defaults to `authorization`) and a boolean to disable the `www-authenticate` header check (use with care!).
 
 **⚠⚠ Warning:** make sure to use the URL of a correctly configured HTTP Basic authenticating server. If the server always responds with a HTTP 2xx response without validating the users, this would allow anyone to log in to your Nextcloud instance with **any username / password combination**. ⚠⚠
 
@@ -153,6 +154,15 @@ Add the following to your `config.php`:
         array(
             'class' => 'OC_User_BasicAuth',
             'arguments' => array('https://example.com/basic_auth'),
+        ),
+    ),
+
+To use a different authorization header and disable the "www-authenticate" header check (for integration with Authelia for example), use the following:
+
+    'user_backends' => array(
+        array(
+            'class' => 'OC_User_BasicAuth',
+            'arguments' => array('https://authelia.example.com/api/verify', 'Proxy-Authorization', true),
         ),
     ),
 


### PR DESCRIPTION
Signed-off-by: Patrick Pacher <patrick.pacher@gmail.com>

**Changes proposed in this pull request:**

This PR adds two additional (optional) parameters to the BasicAuth class:
1. Support for a custom authorization header (defaults to `authorization`)
2. Support to disable the "www-authenticate" canary check

The above changes are required to integrate with services, for example Authelia, that expect a different "Authorization" header and do not reply with "WWW-Authenticate" because they don't want the browsers to show the "User/Password" dialog.

Changes should be backwards compatible.