### PR TITLE
Add username prefix option for IMAP authentication

### DIFF
--- a/lib/imap.php
+++ b/lib/imap.php
@@ -24,6 +24,7 @@ class OC_User_IMAP extends \OCA\user_external\Base {
 	private $domain;
 	private $stripeDomain;
 	private $groupDomain;
+	private $usernamePrefix;
 
 	/**
 	 * Create new IMAP authentication provider
@@ -34,8 +35,17 @@ class OC_User_IMAP extends \OCA\user_external\Base {
 	 * @param string $domain  If provided, loging will be restricted to this domain
 	 * @param boolean $stripeDomain (whether to stripe the domain part from the username or not)
 	 * @param boolean $groupDomain (whether to add the usere to a group corresponding to the domain of the address)
+	 * @param string $usernamePrefix Prefix to prepend to supplied username
 	 */
-	public function __construct($mailbox, $port = null, $sslmode = null, $domain = null, $stripeDomain = true, $groupDomain = false) {
+	public function __construct(
+		$mailbox,
+		$port = null,
+		$sslmode = null,
+		$domain = null,
+		$stripeDomain = true,
+		$groupDomain = false,
+		$usernamePrefix = ''
+	) {
 		parent::__construct($mailbox);
 		$this->mailbox = $mailbox;
 		$this->port = $port === null ? 143 : $port;
@@ -43,6 +53,7 @@ class OC_User_IMAP extends \OCA\user_external\Base {
 		$this->domain = $domain === null ? '' : $domain;
 		$this->stripeDomain = $stripeDomain;
 		$this->groupDomain = $groupDomain;
+		$this->usernamePrefix = $usernamePrefix;
 	}
 
 	/**
@@ -79,6 +90,7 @@ class OC_User_IMAP extends \OCA\user_external\Base {
 		} else {
 			$username = $uid;
  		}
+		$username = $this->usernamePrefix . $username;
 
 		$groups = [];
 		if ($this->groupDomain && $pieces[1]) {


### PR DESCRIPTION
Adds another option to IMAP authentication. If configured, this prefix will be prepended to the username before authenticating against an IMAP server.
The prefix is used for authentication only and not part of the Nextcloud username., making it invisible to the end-user.

Use case: Our company's mail provider uses a cryptic prefix for usernames, and there ist nothing we could do about it. For example, a user's mail address would be `username@example.com`, but the IMAP username would be something like `gr5418962-username`.
To save our users from having to memorize a seemingly random character sequence, this PR allows adding the prefix to the plugin config:
```
array (
    0 => 'mail.example.com',
    1 => 143,
    2 => 'tls',
    3 => NULL,
    4 => true,
    5 => false,
    6 => 'gr5418962-',
),
```
This allows logging in as `username`, which will also be the Nextcloud username. The prefix will never become visible to the user or the application.