### PR TITLE
Examine error code returned by curl handle instead of return value from curl_exec. Using the return value from curl_exec resulted in failure on new mailboxes that did not contain any mail.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix IMAP authentication on empty mailboxes
+  [#164](https://github.com/nextcloud/user_external/pull/164) @tem-hth
 
 ## [3.0.0] - 2022-04-26
 ### Breaking Changes

--- a/lib/IMAP.php
+++ b/lib/IMAP.php
@@ -98,9 +98,10 @@ class IMAP extends Base {
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'CAPABILITY');
 
-		$canconnect = curl_exec($ch);
+		curl_exec($ch);
+		$errorcode = curl_errno($ch);
 
-		if ($canconnect) {
+		if ($errorcode === 0) {
 			curl_close($ch);
 			$uid = mb_strtolower($uid);
 			$this->storeUser($uid, $groups);


### PR DESCRIPTION
fixes #154 