### PR TITLE
Use new types introduced in Nextcloud 21 and bump compatibility

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@
 
 Read the [documentation](https://github.com/nextcloud/user_external#readme) to learn how to configure it!
     ]]></description>
-	<version>1.0.0</version>
+	<version>2.0.0</version>
 	<licence>agpl</licence>
 	<author>Robin Appelman</author>
 	<types>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -32,6 +32,6 @@ Read the [documentation](https://github.com/nextcloud/user_external#readme) to l
 	<bugs>https://github.com/nextcloud/user_external/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/user_external.git</repository>
 	<dependencies>
-		<nextcloud min-version="17" max-version="20" />
+		<nextcloud min-version="21" max-version="21" />
 	</dependencies>
 </info>

--- a/lib/Migration/Version0010Date20200630193751.php
+++ b/lib/Migration/Version0010Date20200630193751.php
@@ -26,8 +26,8 @@ declare(strict_types=1);
 namespace OCA\User_external\Migration;
 
 use Closure;
-use Doctrine\DBAL\Types\Type;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -44,17 +44,17 @@ class Version0010Date20200630193751 extends SimpleMigrationStep {
 
 		if (!$schema->hasTable('users_external')) {
 			$table = $schema->createTable('users_external');
-			$table->addColumn('backend', Type::STRING, [
+			$table->addColumn('backend', Types::STRING, [
 				'notnull' => true,
 				'length' => 128,
 				'default' => '',
 			]);
-			$table->addColumn('uid', Type::STRING, [
+			$table->addColumn('uid', Types::STRING, [
 				'notnull' => true,
 				'length' => 64,
 				'default' => '',
 			]);
-			$table->addColumn('displayname', Type::STRING, [
+			$table->addColumn('displayname', Types::STRING, [
 				'notnull' => false,
 				'length' => 64,
 			]);


### PR DESCRIPTION
Signed-off-by: Ole Morten <om@haaland.biz>

<!--
Thank you for contributing to nextcloud's user_external app!
Plases make sure to sign-off on your commits - see https://github.com/nextcloud/server/blob/master/.github/CONTRIBUTING.md#sign-your-work
-->

Fixes #165.

Changes proposed in this pull request:
 - Use new types.
 - Bump compatibility: I'm not intimately familiar with Nextcloud's APIs, but I suppose using this new class is going to break compatibility with Nextcloud <21.
