### PR TITLE
Mark as compatible with Nextcloud v23

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -32,6 +32,6 @@ Read the [documentation](https://github.com/nextcloud/user_external#readme) to l
 	<bugs>https://github.com/nextcloud/user_external/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/user_external.git</repository>
 	<dependencies>
-		<nextcloud min-version="21" max-version="22" />
+		<nextcloud min-version="21" max-version="23" />
 	</dependencies>
 </info>


### PR DESCRIPTION
Fixes #186

Changes proposed in this pull request:
 - Simply mark this app as compatible with v23. This was confirmed to work by several people in #186.