### PR TITLE
🐛 FIX: create correctly named archive file for workflow release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,9 @@ appstore:
 			--certificate=$(cert_dir)/$(app_name).crt\
 			--path=$(sign_dir)/$(app_name); \
 	fi
-	tar -czf $(build_dir)/$(app_name)-$(version).tar.gz \
+	tar -czf $(build_dir)/$(app_name).tar.gz \
 		-C $(sign_dir) $(app_name)
 	@if [ -f $(cert_dir)/$(app_name).key ]; then \
 		echo "Signing package…"; \
-		openssl dgst -sha512 -sign $(cert_dir)/$(app_name).key $(build_dir)/$(app_name)-$(version).tar.gz | openssl base64; \
+		openssl dgst -sha512 -sign $(cert_dir)/$(app_name).key $(build_dir)/$(app_name).tar.gz | openssl base64; \
 	fi


### PR DESCRIPTION
 a small fix needed to make the automated release via workflow working

please review @nextcloud/user_external