### PR TITLE
Add the option for digest authentication for webdav.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,11 @@ Add the following to your `config.php`:
 
     'user_backends' => array(
         array(
-            'class' => '\OCA\UserExternal\WebDAVAuth',
-            'arguments' => array('https://example.com/webdav'),
+            'class' => '\OCA\UserExternal\WebDavAuth',
+            'arguments' => array(
+                'https://example.com/webdav',
+                'basic',  // alternative: 'digest'
+            ),
         ),
     ),
 

--- a/lib/WebDavAuth.php
+++ b/lib/WebDavAuth.php
@@ -11,9 +11,9 @@ namespace OCA\UserExternal;
 class WebDavAuth extends Base {
 	private $webDavAuthUrl;
 
-	public function __construct($webDavAuthUrl) {
-		parent::__construct($webDavAuthUrl);
+	public function __construct($webDavAuthUrl, $authType = 'basic') {
 		$this->webDavAuthUrl = $webDavAuthUrl;
+		$this->authType = $authType;
 	}
 
 	/**
@@ -31,12 +31,74 @@ class WebDavAuth extends Base {
 			return false;
 		}
 		list($protocol, $path) = $arr;
-		$url = $protocol.'://'.urlencode($uid).':'.urlencode($password).'@'.$path;
-		$headers = get_headers($url);
-		if ($headers === false) {
-			\OC::$server->getLogger()->error('ERROR: Not possible to connect to WebDAV Url: "'.$protocol.'://'.$path.'" ', ['app' => 'user_external']);
+		$url = $protocol.'://'.$path;
+
+		switch ($this->authType) {
+			case 'digest':
+				// Initial unauthenticated request
+				@file_get_contents($url);
+				if (!isset($http_response_header)) {
+					\OC::$server->getLogger()->error('ERROR: Not possible to connect to WebDAV Url: "'.$protocol.'://'.$path.'" ', ['app' => 'user_external']);
+					return false;
+				}
+
+				// Find the WWW-Authenticate header
+				foreach ($http_response_header as $header) {
+					if (strpos($header, 'WWW-Authenticate: Digest') === 0) {
+						$auth_header = substr($header, strlen('WWW-Authenticate: Digest '));
+						break;
+					}
+				}
+
+				// Parse the header to get the parameters
+				$auth_params = array();
+				foreach (explode(',', $auth_header) as $param) {
+					list($key, $value) = explode('=', $param, 2);
+					$auth_params[trim($key)] = trim($value, ' "');
+				}
+
+				// Generate a cnonce (client nonce) value
+				$cnonce = bin2hex(openssl_random_pseudo_bytes(8));
+
+				// Generate the response value
+				$A1 = md5($uid . ':' . $auth_params['realm'] . ':' . $password);
+				$A2 = md5('GET:' . $url);
+				$response = md5($A1 . ':' . $auth_params['nonce'] . ':00000001:' . $cnonce . ':auth:' . $A2);
+
+				// Construct the Authorization header
+				$auth_header = 'Authorization: Digest username="' . $uid . '", realm="' . $auth_params['realm'] .
+					'", nonce="' . $auth_params['nonce'] . '", uri="' . $url . '", cnonce="' . $cnonce .
+					'", nc=00000001, qop=auth, response="' . $response . '", opaque="' . $auth_params['opaque'] . '"';
+
+				// Make the authenticated request
+				$context = stream_context_create(array(
+					'http' => array(
+						'method' => 'GET',
+						'header' => $auth_header
+					)
+				));
+				break;
+			case 'basic':
+				$url = $protocol.'://'.urlencode($uid).':'.urlencode($password).'@'.$path;
+				$context = stream_context_create(array(
+					'http' => array(
+						'method' => 'GET',
+						'header' => 'Authorization: Basic ' . base64_encode($uid . ':' . $password)
+					)
+				));
+				break;
+			default:
+				\OC::$server->getLogger()->error('ERROR: Invalid authentication type: "'.$this->authType.'". Expected "basic" or "digest".', ['app' => 'user_external']);
+				return false;
+		}
+
+		$result = @file_get_contents($url, false, $context);
+		if ($result === false) {
+			\OC::$server->getLogger()->error('ERROR: Not possible to connect to WebDAV Url: "'.$url.'" ', ['app' => 'user_external']);
 			return false;
 		}
+
+		$headers = $http_response_header;
 		$returnCode = substr($headers[0], 9, 3);
 
 		if (substr($returnCode, 0, 1) === '2') {


### PR DESCRIPTION
Fixes #225

Changes proposed in this pull request:
- add option to specify either 'basic' or 'digest' in the config for WebDav.
- 'basic' (which is also the default if you don't specify anything) is the same as before: it uses basic authentication
- 'digest' uses digest authentication