### PR TITLE
Distinguish wrong credentials from other problems (IMAP)

### DIFF
--- a/lib/IMAP.php
+++ b/lib/IMAP.php
@@ -106,9 +106,29 @@ class IMAP extends Base {
 			$uid = mb_strtolower($uid);
 			$this->storeUser($uid, $groups);
 			return $uid;
+		} elseif ($errorcode === CURLE_COULDNT_CONNECT ||
+			   $errorcode === CURLE_SSL_CONNECT_ERROR ||
+			   $errorcode === 28) {
+			# This is not defined in PHP-8.x
+			# 28: CURLE_OPERATION_TIMEDOUT
+			\OC::$server->getLogger()->error(
+				'ERROR: Could not connect to imap server via curl: ' .  curl_strerror($errorcode),
+				['app' => 'user_external']
+			);
+		} elseif ($errorcode === 9 ||
+			   $errorcode === 67 ||
+			   $errorcode === 94) {
+			# These are not defined in PHP-8.x
+			# 9: CURLE_REMOTE_ACCESS_DENIED
+			# 67: CURLE_LOGIN_DENIED
+			# 94: CURLE_AUTH_ERROR)
+			\OC::$server->getLogger()->error(
+				'ERROR: IMAP Login failed via curl: ' .  curl_strerror($errorcode),
+				['app' => 'user_external']
+			);
 		} else {
 			\OC::$server->getLogger()->error(
-				'ERROR: Could not connect to imap server via curl: '.curl_error($ch),
+			'ERROR: IMAP server returned an error: ' . $errorcode . ' / ' . curl_strerror($errorcode),
 				['app' => 'user_external']
 			);
 		}


### PR DESCRIPTION
Changes proposed in this pull request:
 - evaluate cURL error code to log the reason why a login failed

Verifying login data can fail for a number of reasons like temporary connection failure to the IMAP server, Internal problems of the IMAP server, or actually wrong username / password combination.

This change logs the reason for login failures, helping server admins to diagnose login problems and better support their users.

Ideally, we would have an option to pass the reason upwards, so the NextCloud login system can show appropriate errors to users attempting to login.
