### PR TITLE
Fix out-of-bound array access (IMAP)

### DIFF
--- a/lib/IMAP.php
+++ b/lib/IMAP.php
@@ -82,7 +82,7 @@ class IMAP extends Base {
 		}
 
 		$groups = [];
-		if ($this->groupDomain && $pieces[1]) {
+		if ((count($pieces) > 1) && $this->groupDomain && $pieces[1]) {
 			$groups[] = $pieces[1];
 		}
 


### PR DESCRIPTION
Fixes #169 

The IMAP method allows user names with or without a domain part.  For user names without a domain part, it still tries to access the (then non-existing) domain, resulting in "Error: Undefined array key 1 at .../nextcloud/apps/user_external/lib/IMAP.php#85" log messages.
