### PR TITLE
refactor(appinfo): allow for nextcloud 26

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@
 
 Read the [documentation](https://github.com/nextcloud/user_external#readme) to learn how to configure it!
     ]]></description>
-	<version>3.1.0</version>
+	<version>3.1.1</version>
 	<licence>agpl</licence>
 	<author>Robin Appelman</author>
 	<namespace>UserExternal</namespace>
@@ -33,6 +33,6 @@ Read the [documentation](https://github.com/nextcloud/user_external#readme) to l
 	<bugs>https://github.com/nextcloud/user_external/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/user_external.git</repository>
 	<dependencies>
-		<nextcloud min-version="22" max-version="25" />
+		<nextcloud min-version="22" max-version="26" />
 	</dependencies>
 </info>


### PR DESCRIPTION
Fixes https://github.com/nextcloud/user_external/issues/222

Changes proposed in this pull request:
- update compatible version to 26
- update minor version for UserExternal

As many users already force updated it successful, why not just changing the version.. unless someone who knows better wants to have a look!