### PR TITLE
add CURL login options for IMAP Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Add the following to your `config.php`:
         array(
             'class' => '\OCA\UserExternal\IMAP',
             'arguments' => array(
-                '127.0.0.1', 993, 'ssl', 'example.com', true, false
+                '127.0.0.1', 993, 'ssl', 'example.com', true, false, 'AUTH=DIGEST-MD5'
             ),
         ),
     ),
@@ -89,7 +89,9 @@ is set to true, after successfull login the domain part will be striped and
 the rest used as username in Nextcloud. e.g. 'username@example.com' will be
 'username' in Nextcloud. The sixth parameter toggles whether on creation of
 the user, it is added to a group corresponding to the name of the domain part
-of the address. 
+of the address. The seventh parameter allows you specify - if is set - login
+options (for example, what authentication method you prefer - AUTH=PLAIN or 
+AUTH=DIGEST-MD5 or AUTH=NTLM or AUTH=GSSAPI or AUTH=AUTO or AUTH=* ).
 
 **⚠⚠ Warning:** If you are [**upgrading** from versions **<0.6.0**](https://github.com/nextcloud/user_external/releases/tag/v0.6.0), beside adapting your `config.php` you also have to change the `backend` column in the `users_external` table of the database. In your pre 0.6.0 database it may look like `{127.0.0.1:993/imap/ssl/readonly}INBOX` or similar, but now it has to be just `127.0.0.1` for everything to work flawless again. ⚠⚠
 

--- a/lib/IMAP.php
+++ b/lib/IMAP.php
@@ -35,8 +35,9 @@ class IMAP extends Base {
 	 * @param string $domain  If provided, loging will be restricted to this domain
 	 * @param boolean $stripeDomain (whether to stripe the domain part from the username or not)
 	 * @param boolean $groupDomain (whether to add the usere to a group corresponding to the domain of the address)
+  	 * @param string $loginOptions set login options (for example authorization method AUTH=PLAIN, AUTH=DIGEST-MD5, AUTH=NTLM, AUTH=GSSAPI, AUTH=AUTO, AUTH=* and more)
 	 */
-	public function __construct($mailbox, $port = null, $sslmode = null, $domain = null, $stripeDomain = true, $groupDomain = false) {
+	public function __construct($mailbox, $port = null, $sslmode = null, $domain = null, $stripeDomain = true, $groupDomain = false, $loginOptions = null) {
 		parent::__construct($mailbox);
 		$this->mailbox = $mailbox;
 		$this->port = $port === null ? 143 : $port;
@@ -44,6 +45,7 @@ class IMAP extends Base {
 		$this->domain = $domain === null ? '' : $domain;
 		$this->stripeDomain = $stripeDomain;
 		$this->groupDomain = $groupDomain;
+		$this->loginOptions = $loginOptions;
 	}
 
 	/**
@@ -97,6 +99,10 @@ class IMAP extends Base {
 		curl_setopt($ch, CURLOPT_USERPWD, $username.":".$password);
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'CAPABILITY');
+
+		if (is_string($this->loginOptions)) {
+                       curl_setopt($ch, CURLOPT_LOGIN_OPTIONS, $this->loginOptions);
+                }
 
 		curl_exec($ch);
 		$errorcode = curl_errno($ch);


### PR DESCRIPTION
Fixes https://github.com/nextcloud/user_external/issues/153

Changes proposed in this pull request:

-  add one IMAP config parameter
-  allows to choose IMAP login options

All merit goes to @qaxi and @violoncelloCH, in https://github.com/nextcloud/user_external/pull/196 and https://github.com/nextcloud/user_external/pull/176. I'm just trying to getting things done. 😃 

Signed-off-by: Federico Lazcano <flazcano@tau.org.ar>