### PR TITLE
Wrong class name corrected with : `\OCA\UserExternal\WebDavAuth' inst…

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Add the following to your `config.php`:
 
     'user_backends' => array(
         array(
-            'class' => '\OCA\UserExternal\WebDAVAuth',
+            'class' => '\OCA\UserExternal\WebDavAuth',
             'arguments' => array('https://example.com/webdav'),
         ),
     ),


### PR DESCRIPTION
Fixes 

Changes proposed in this pull request:
 - Error in readme