### PR TITLE
Add support for NC 28

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,6 +33,6 @@ Read the [documentation](https://github.com/nextcloud/user_external#readme) to l
 	<bugs>https://github.com/nextcloud/user_external/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/user_external.git</repository>
 	<dependencies>
-		<nextcloud min-version="25" max-version="27" />
+		<nextcloud min-version="25" max-version="28" />
 	</dependencies>
 </info>


### PR DESCRIPTION
<!--
Thank you for contributing to nextcloud's user_external app!
Plases make sure to sign-off on your commits - see https://github.com/nextcloud/server/blob/master/.github/CONTRIBUTING.md#sign-your-work
-->

Fixes #240

Changes proposed in this pull request:
 - Add support for NC 28

This is untested, but only based on the success from #240
