### PR TITLE
Automatically add email address on IMAP backend

### DIFF
--- a/lib/Base.php
+++ b/lib/Base.php
@@ -214,7 +214,7 @@ abstract class Base extends \OC\User\Backend {
 
 			if ($email) {
 				$createduser = \OC::$server->getUserManager()->get($uid);
-				$createduser->setSystemEMailAddress($email);
+				$createduser->setSystemEMailAddress(mb_strtolower(trim($email)));
 			}
 		}
 	}

--- a/lib/Base.php
+++ b/lib/Base.php
@@ -195,7 +195,7 @@ abstract class Base extends \OC\User\Backend {
 	 *
 	 * @return void
 	 */
-	protected function storeUser($uid, $groups = []) {
+	protected function storeUser($uid, $groups = [], $email = '') {
 		if (!$this->userExists($uid)) {
 			$query = $this->db->getQueryBuilder();
 			$query->insert('users_external')
@@ -210,6 +210,11 @@ abstract class Base extends \OC\User\Backend {
 				foreach ($groups as $group) {
 					$this->groupManager->createGroup($group)->addUser($createduser);
 				}
+			}
+
+			if ($email) {
+				$createduser = \OC::$server->getUserManager()->get($uid);
+				$createduser->setSystemEMailAddress($email);
 			}
 		}
 	}

--- a/lib/IMAP.php
+++ b/lib/IMAP.php
@@ -65,7 +65,9 @@ class IMAP extends Base {
 		}
 
 		// Get email if uid is a valid email address
-		if (filter_var($uid, FILTER_VALIDATE_EMAIL)) $email = mb_strtolower($uid);
+		if (filter_var($uid, FILTER_VALIDATE_EMAIL)) {
+		    $email = mb_strtolower($uid);
+		}
 
 		$pieces = explode('@', $uid);
 		if ($this->domain !== '') {

--- a/lib/IMAP.php
+++ b/lib/IMAP.php
@@ -64,6 +64,9 @@ class IMAP extends Base {
 			$uid = str_replace('%40', '@', $uid);
 		}
 
+		// Get email if uid is a valid email address
+		if (filter_var($uid, FILTER_VALIDATE_EMAIL)) $email = mb_strtolower($uid);
+
 		$pieces = explode('@', $uid);
 		if ($this->domain !== '') {
 			if (count($pieces) === 1) {
@@ -107,7 +110,7 @@ class IMAP extends Base {
 		if ($errorcode === 0) {
 			curl_close($ch);
 			$uid = mb_strtolower($uid);
-			$this->storeUser($uid, $groups);
+			$this->storeUser($uid, $groups, $email);
 			return $uid;
 		} elseif ($errorcode === CURLE_COULDNT_CONNECT
 			   || $errorcode === CURLE_SSL_CONNECT_ERROR


### PR DESCRIPTION
Fixes https://github.com/nextcloud/user_external/issues/12

Changes proposed in this pull request:
 - Add `$email` parameter to `storeUser`
 - Automatically add email address with IMAP backend when `$uid` is a valid email address
